### PR TITLE
fix: special cases for component names

### DIFF
--- a/apps/native-mcp/src/api/utils/component-name.ts
+++ b/apps/native-mcp/src/api/utils/component-name.ts
@@ -6,12 +6,26 @@
  * - "DateField" → "date-field"
  * - "Alert Dialog" → "alert-dialog"
  * - "Scroll Shadow" → "scroll-shadow"
+ * - "ComboBox" → "combobox" (special case - file is combobox.mdx, not combo-box.mdx)
+ * - "ListBox" → "listbox" (special case - file is listbox.mdx, not list-box.mdx)
+ * - "TextArea" → "textarea" (special case - file is textarea.mdx, not text-area.mdx)
  */
 export function componentNameToKebab(name: string): string {
+  const trimmed = name.trim();
+
+  // Special case mappings for components that don't follow standard PascalCase-to-kebab conversion
+  const specialCases: Record<string, string> = {
+    ComboBox: "combobox",
+    ListBox: "listbox",
+    TextArea: "textarea",
+  };
+
+  if (specialCases[trimmed]) {
+    return specialCases[trimmed];
+  }
+
   return (
-    name
-      // Trim leading/trailing whitespace
-      .trim()
+    trimmed
       // First, replace spaces with hyphens
       .replace(/\s+/g, "-")
       // Then convert PascalCase to kebab-case by adding hyphen before uppercase letters

--- a/apps/react-mcp/src/api/utils/component-name.ts
+++ b/apps/react-mcp/src/api/utils/component-name.ts
@@ -6,12 +6,24 @@
  * - "DateField" → "date-field"
  * - "Alert Dialog" → "alert-dialog"
  * - "Scroll Shadow" → "scroll-shadow"
+ * - "ComboBox" → "combobox" (special case - file is combobox.mdx, not combo-box.mdx)
  */
 export function componentNameToKebab(name: string): string {
+  const trimmed = name.trim();
+
+  // Special case mappings for components that don't follow standard PascalCase-to-kebab conversion
+  const specialCases: Record<string, string> = {
+    ComboBox: "combobox",
+    ListBox: "listbox",
+    TextArea: "textarea",
+  };
+
+  if (specialCases[trimmed]) {
+    return specialCases[trimmed];
+  }
+
   return (
-    name
-      // Trim leading/trailing whitespace
-      .trim()
+    trimmed
       // First, replace spaces with hyphens
       .replace(/\s+/g, "-")
       // Then convert PascalCase to kebab-case by adding hyphen before uppercase letters


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

certain components do not follow the naming rule of others
for example, ComboBox file isn't combo-box, but combobox

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
