### PR TITLE
fix: use v1 ctx endpoint

### DIFF
--- a/apps/native-mcp/src/mcp/lib/shared-context.ts
+++ b/apps/native-mcp/src/mcp/lib/shared-context.ts
@@ -5,7 +5,7 @@ import {fetchApi} from "./fetch";
 let cachedContext: SharedContext | null = null;
 
 /**
- * Fetch shared initialization context from the /ctx endpoint
+ * Fetch shared initialization context from the /v1/ctx endpoint
  * This is called once during MCP server initialization to populate
  * all tool input schemas with dynamic enums.
  */
@@ -27,7 +27,7 @@ export async function getSharedContext(apiBaseUrl?: string): Promise<SharedConte
       };
       version: string;
       timestamp: number;
-    }>("/ctx", apiBaseUrl);
+    }>("/v1/ctx", apiBaseUrl);
 
     // Cache the context
     cachedContext = {

--- a/apps/react-mcp/src/mcp/lib/shared-context.ts
+++ b/apps/react-mcp/src/mcp/lib/shared-context.ts
@@ -5,7 +5,7 @@ import {fetchApi} from "./fetch";
 let cachedContext: SharedContext | null = null;
 
 /**
- * Fetch shared initialization context from the /ctx endpoint
+ * Fetch shared initialization context from the /v1/ctx endpoint
  * This is called once during MCP server initialization to populate
  * all tool input schemas with dynamic enums.
  */
@@ -27,7 +27,7 @@ export async function getSharedContext(apiBaseUrl?: string): Promise<SharedConte
       };
       version: string;
       timestamp: number;
-    }>("/ctx", apiBaseUrl);
+    }>("/v1/ctx", apiBaseUrl);
 
     // Cache the context
     cachedContext = {


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

legacy /ctx endpoint was being used instead of /v1/ctx

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
