### PR TITLE
fix: remove component name exceptions

### DIFF
--- a/apps/native-mcp/src/api/utils/component-name.ts
+++ b/apps/native-mcp/src/api/utils/component-name.ts
@@ -6,23 +6,12 @@
  * - "DateField" → "date-field"
  * - "Alert Dialog" → "alert-dialog"
  * - "Scroll Shadow" → "scroll-shadow"
- * - "ComboBox" → "combobox" (special case - file is combobox.mdx, not combo-box.mdx)
- * - "ListBox" → "listbox" (special case - file is listbox.mdx, not list-box.mdx)
- * - "TextArea" → "textarea" (special case - file is textarea.mdx, not text-area.mdx)
+ * - "ComboBox" → "combo-box"
+ * - "ListBox" → "list-box"
+ * - "TextArea" → "text-area"
  */
 export function componentNameToKebab(name: string): string {
   const trimmed = name.trim();
-
-  // Special case mappings for components that don't follow standard PascalCase-to-kebab conversion
-  const specialCases: Record<string, string> = {
-    ComboBox: "combobox",
-    ListBox: "listbox",
-    TextArea: "textarea",
-  };
-
-  if (specialCases[trimmed]) {
-    return specialCases[trimmed];
-  }
 
   return (
     trimmed

--- a/apps/react-mcp/src/api/utils/component-name.ts
+++ b/apps/react-mcp/src/api/utils/component-name.ts
@@ -6,21 +6,12 @@
  * - "DateField" → "date-field"
  * - "Alert Dialog" → "alert-dialog"
  * - "Scroll Shadow" → "scroll-shadow"
- * - "ComboBox" → "combobox" (special case - file is combobox.mdx, not combo-box.mdx)
+ * - "ComboBox" → "combo-box"
+ * - "ListBox" → "list-box"
+ * - "TextArea" → "text-area"
  */
 export function componentNameToKebab(name: string): string {
   const trimmed = name.trim();
-
-  // Special case mappings for components that don't follow standard PascalCase-to-kebab conversion
-  const specialCases: Record<string, string> = {
-    ComboBox: "combobox",
-    ListBox: "listbox",
-    TextArea: "textarea",
-  };
-
-  if (specialCases[trimmed]) {
-    return specialCases[trimmed];
-  }
 
   return (
     trimmed


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

component naming in heroui react and native have been standardized
remove the component name exceptions from utils

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
https://github.com/heroui-inc/heroui-mcp/pull/59
---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
