### PR TITLE
fix: add component not found error msg on get component docs fail

### DIFF
--- a/apps/native-mcp/src/api/routes/components.ts
+++ b/apps/native-mcp/src/api/routes/components.ts
@@ -114,9 +114,14 @@ components.post("/docs", zValidator("json", ComponentsRequestSchema), async (c) 
               },
             });
 
+            const errorMessage =
+              response.status === 404 || response.status === 500
+                ? "Component not found"
+                : `${response.status} ${response.statusText}`;
+
             return {
               component,
-              error: `${response.status} ${response.statusText}`,
+              error: errorMessage,
               status: response.status,
               statusText: response.statusText,
               url: docUrl,
@@ -158,9 +163,18 @@ components.post("/docs", zValidator("json", ComponentsRequestSchema), async (c) 
             },
           });
 
+          const errMsg = error instanceof Error ? error.message : String(error);
+          const errorMessage =
+            errMsg.includes("404") ||
+            errMsg.includes("500") ||
+            errMsg.toLowerCase().includes("not found") ||
+            errMsg.toLowerCase().includes("internal server error")
+              ? "Component not found"
+              : errMsg;
+
           return {
             component,
-            error: error instanceof Error ? error.message : String(error),
+            error: errorMessage,
             url: docUrl,
           };
         }

--- a/apps/react-mcp/src/api/routes/components.ts
+++ b/apps/react-mcp/src/api/routes/components.ts
@@ -123,9 +123,14 @@ components.post("/docs", zValidator("json", ComponentsRequestSchema), async (c) 
               },
             });
 
+            const errorMessage =
+              response.status === 404 || response.status === 500
+                ? "Component not found"
+                : `${response.status} ${response.statusText}`;
+
             return {
               component,
-              error: `${response.status} ${response.statusText}`,
+              error: errorMessage,
               status: response.status,
               statusText: response.statusText,
               url: docUrl,
@@ -168,9 +173,18 @@ components.post("/docs", zValidator("json", ComponentsRequestSchema), async (c) 
             },
           });
 
+          const errMsg = error instanceof Error ? error.message : String(error);
+          const errorMessage =
+            errMsg.includes("404") ||
+            errMsg.includes("500") ||
+            errMsg.toLowerCase().includes("not found") ||
+            errMsg.toLowerCase().includes("internal server error")
+              ? "Component not found"
+              : errMsg;
+
           return {
             component,
-            error: error instanceof Error ? error.message : String(error),
+            error: errorMessage,
             url: docUrl,
           };
         }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

If getting component docs fail, return a `Component not found` error message instead of 500
Not ideal, but due to Next.js handling of .mdx files it will return 500 instead of 404 for non-existent files

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
