### PR TITLE
fix: broken CI + update heroui doc link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,10 +269,10 @@ Environment variables are configured in `wrangler.toml` for API servers.
 
 ### Component Data Extraction
 
-The server extracts component data directly from `v3.heroui.com` and stores it in Cloudflare R2:
+The server extracts component data directly from `heroui.com` and stores it in Cloudflare R2:
 
-- **React MCP**: Fetches component documentation from `https://v3.heroui.com/docs/react/components/` using `llms.txt` manifest
-- **Native MCP**: Fetches component documentation from `https://v3.heroui.com/docs/native/components/` using `llms.txt` manifest
+- **React MCP**: Fetches component documentation from `https://heroui.com/docs/react/components/` using `llms.txt` manifest
+- **Native MCP**: Fetches component documentation from `https://heroui.com/docs/native/components/` using `llms.txt` manifest
 
 Data is stored as `ctx.json` in R2, containing components list, documentation paths, version, and timestamp.
 
@@ -296,7 +296,7 @@ Data is automatically extracted via GitHub Actions when:
 
 ### Rate Limiting
 
-The extraction scripts fetch documentation directly from `v3.heroui.com`:
+The extraction scripts fetch documentation directly from `heroui.com`:
 
 - Documentation is fetched from public URLs (no authentication required)
 - Rate limiting is handled by the documentation server
@@ -345,7 +345,11 @@ export const myTool: Tool = {
       };
     };
 
-    server.registerTool(name, { description, inputSchema: inputSchema.shape }, handler as any);
+    server.registerTool(
+      name,
+      { description, inputSchema: inputSchema.shape },
+      handler as any,
+    );
   },
 };
 ```
@@ -396,7 +400,7 @@ Each MCP package follows a unified architecture:
 
 2. **REST API** - Cloudflare Worker
    - Serves component data from R2 storage
-   - Fetches documentation directly from v3.heroui.com when needed
+   - Fetches documentation directly from heroui.com when needed
    - Provides analytics and authentication middleware
 
 3. **R2 Storage** - Cloudflare R2 bucket
@@ -404,7 +408,7 @@ Each MCP package follows a unified architecture:
    - Single source of truth for component metadata
 
 4. **Data Extraction** - CLI scripts
-   - Fetches component data from v3.heroui.com using `llms.txt` manifest
+   - Fetches component data from heroui.com using `llms.txt` manifest
    - Extracts minimal metadata (name, links) from component documentation
    - Uploads consolidated `ctx.json` to R2
 

--- a/apps/migration-mcp/src/mcp/lib/migration-docs.ts
+++ b/apps/migration-mcp/src/mcp/lib/migration-docs.ts
@@ -2,7 +2,7 @@
  * Utility for reading migration documentation from the docs site
  */
 
-const DEFAULT_DOCS_BASE_URL = "https://v3.heroui.com/docs/react/migration";
+const DEFAULT_DOCS_BASE_URL = "https://heroui.com/docs/react/migration";
 
 function getDocsSiteUrl(filename: string, baseUrl?: string): string {
   const docsBase = baseUrl || DEFAULT_DOCS_BASE_URL;

--- a/apps/migration-mcp/src/mcp/tools/get-hooks-migration-guide.ts
+++ b/apps/migration-mcp/src/mcp/tools/get-hooks-migration-guide.ts
@@ -71,7 +71,7 @@ Use this tool to get hooks-specific migration information. For the main migratio
             content: [
               {
                 type: "text",
-                text: `Hooks migration guide not yet available.\n\nThe documentation is being prepared and will be available soon. Please check https://v3.heroui.com for the latest migration information.`,
+                text: `Hooks migration guide not yet available.\n\nThe documentation is being prepared and will be available soon. Please check https://heroui.com for the latest migration information.`,
               },
             ],
           };

--- a/apps/migration-mcp/src/mcp/tools/get-migration-guide.ts
+++ b/apps/migration-mcp/src/mcp/tools/get-migration-guide.ts
@@ -90,7 +90,7 @@ The migrationType parameter allows you to choose between "full" (default) and "i
             content: [
               {
                 type: "text",
-                text: `Agent migration guide not yet available.\n\nThe documentation is being prepared and will be available soon. Please check https://v3.heroui.com for the latest migration information.`,
+                text: `Agent migration guide not yet available.\n\nThe documentation is being prepared and will be available soon. Please check https://heroui.com for the latest migration information.`,
               },
             ],
           };

--- a/apps/migration-mcp/src/mcp/tools/get-styling-migration-guide.ts
+++ b/apps/migration-mcp/src/mcp/tools/get-styling-migration-guide.ts
@@ -73,7 +73,7 @@ Use this tool to get styling-specific migration information. For the main migrat
             content: [
               {
                 type: "text",
-                text: `Styling migration guide not yet available.\n\nThe documentation is being prepared and will be available soon. Please check https://v3.heroui.com for the latest migration information.`,
+                text: `Styling migration guide not yet available.\n\nThe documentation is being prepared and will be available soon. Please check https://heroui.com for the latest migration information.`,
               },
             ],
           };

--- a/apps/migration-mcp/wrangler.toml
+++ b/apps/migration-mcp/wrangler.toml
@@ -16,7 +16,7 @@ compatibility_flags = ["nodejs_compat"]
 [env.development.vars]
 NODE_ENV = "development"
 POSTHOG_HOST = "https://us.i.posthog.com"
-MIGRATION_DOCS_BASE_URL = "https://v3.heroui.com/docs/react/migration"
+MIGRATION_DOCS_BASE_URL = "https://heroui.com/docs/react/migration"
 
 # ------------------------------------------------------------
 # -- Staging Environment
@@ -42,7 +42,7 @@ routes = [
 [env.production.vars]
 NODE_ENV = "production"
 POSTHOG_HOST = "https://us.i.posthog.com"
-MIGRATION_DOCS_BASE_URL = "https://v3.heroui.com/docs/react/migration"
+MIGRATION_DOCS_BASE_URL = "https://heroui.com/docs/react/migration"
 
 # ------------------------------------------------------------
 # -- Worker Settings

--- a/apps/native-mcp/README.md
+++ b/apps/native-mcp/README.md
@@ -146,7 +146,7 @@ List all available HeroUI Native components (always returns latest version).
 
 ### `get_component_docs`
 
-Get complete component documentation (including examples, props, usage) directly from v3.heroui.com. This tool consolidates component information, props, and examples into a single call.
+Get complete component documentation (including examples, props, usage) directly from heroui.com. This tool consolidates component information, props, and examples into a single call.
 
 ```javascript
 // Parameters
@@ -167,7 +167,7 @@ Get complete component documentation (including examples, props, usage) directly
 
 ### `get_docs`
 
-Get HeroUI Native documentation content for guides, principles, and release notes (NOT component docs). Fetches official documentation from v3.heroui.com.
+Get HeroUI Native documentation content for guides, principles, and release notes (NOT component docs). Fetches official documentation from heroui.com.
 
 ```javascript
 // Parameters

--- a/apps/native-mcp/src/api/routes/components.test.ts
+++ b/apps/native-mcp/src/api/routes/components.test.ts
@@ -49,7 +49,7 @@ describe("Components API", () => {
         expect(result).toHaveProperty("contentType");
         expect(typeof result.url).toBe("string");
         if (result.url) {
-          expect(result.url.includes("v3.heroui.com")).toBe(true);
+          expect(result.url.includes("heroui.com")).toBe(true);
         }
       }
     });

--- a/apps/native-mcp/src/api/routes/components.ts
+++ b/apps/native-mcp/src/api/routes/components.ts
@@ -81,7 +81,7 @@ components.post("/docs", zValidator("json", ComponentsRequestSchema), async (c) 
     const docResults = await Promise.all(
       componentNames.map(async (component) => {
         const kebabName = componentNameToKebab(component);
-        const docUrl = `https://v3.heroui.com/docs/native/components/${kebabName}.mdx`;
+        const docUrl = `https://heroui.com/docs/native/components/${kebabName}.mdx`;
 
         try {
           const response = await fetch(docUrl);

--- a/apps/native-mcp/src/api/routes/docs.test.ts
+++ b/apps/native-mcp/src/api/routes/docs.test.ts
@@ -30,7 +30,7 @@ describe("Docs API", () => {
         expect(data).toHaveProperty("contentType");
         expect(typeof data.url).toBe("string");
         if (data.url) {
-          expect(data.url.includes("v3.heroui.com")).toBe(true);
+          expect(data.url.includes("heroui.com")).toBe(true);
         }
       }
     });

--- a/apps/native-mcp/src/api/routes/docs.ts
+++ b/apps/native-mcp/src/api/routes/docs.ts
@@ -54,7 +54,7 @@ docs.get("*", async (c) => {
     // Add /docs/ prefix and .mdx extension
     path = `/docs/${path}.mdx`;
 
-    const docUrl = `https://v3.heroui.com${path}`;
+    const docUrl = `https://heroui.com${path}`;
 
     const response = await fetch(docUrl);
 
@@ -119,7 +119,7 @@ docs.get("*", async (c) => {
       contentType,
     });
   } catch (error) {
-    const docUrl = `https://v3.heroui.com${path}`;
+    const docUrl = `https://heroui.com${path}`;
 
     analytics.trackError({
       error,

--- a/apps/native-mcp/src/extraction/extractors/components.ts
+++ b/apps/native-mcp/src/extraction/extractors/components.ts
@@ -14,7 +14,7 @@ export type {NativeComponentDefinition};
 export type NativeComponentDataset = Record<string, NativeComponentDefinition>;
 
 /**
- * Component extractor - extracts HeroUI Native component documentation from v3.heroui.com
+ * Component extractor - extracts HeroUI Native component documentation from heroui.com
  */
 export class ComponentExtractor extends BaseExtractor {
   private parser: NativeParser;
@@ -43,13 +43,13 @@ export class ComponentExtractor extends BaseExtractor {
     };
   }> {
     console.log("🔍 Extracting HeroUI Native from llms.txt...");
-    console.log(`📍 Fetching docs from v3.heroui.com`);
+    console.log(`📍 Fetching docs from heroui.com`);
 
     // Update parser with the correct ref
     this.parser = new NativeParser(ref);
 
     // Step 1: Fetch llms.txt
-    const llmsResponse = await fetch("https://v3.heroui.com/native/llms.txt");
+    const llmsResponse = await fetch("https://heroui.com/native/llms.txt");
     if (!llmsResponse.ok) {
       throw new Error(`Failed to fetch llms.txt: ${llmsResponse.status}`);
     }
@@ -59,9 +59,9 @@ export class ComponentExtractor extends BaseExtractor {
     const componentUrls = parseLlmsTxt(llmsContent);
     console.log(`📄 Found ${componentUrls.length} components in llms.txt`);
 
-    // Step 3: Fetch component docs from v3.heroui.com
+    // Step 3: Fetch component docs from heroui.com
     const components: NativeComponentDataset = {};
-    const CONCURRENCY = 10; // Fetch from v3.heroui.com (no GitHub rate limits)
+    const CONCURRENCY = 10; // Fetch from heroui.com (no GitHub rate limits)
     const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
     const DELAY_MS = 50; // Small delay between batches
 
@@ -77,8 +77,8 @@ export class ComponentExtractor extends BaseExtractor {
 
         console.log(`   Processing ${componentName}...`);
 
-        // Fetch component docs directly from v3.heroui.com
-        const docUrl = `https://v3.heroui.com${componentUrl.url}.mdx`;
+        // Fetch component docs directly from heroui.com
+        const docUrl = `https://heroui.com${componentUrl.url}.mdx`;
         const response = await fetch(docUrl);
 
         if (!response.ok) {

--- a/apps/native-mcp/src/extraction/utils/llms-parser.ts
+++ b/apps/native-mcp/src/extraction/utils/llms-parser.ts
@@ -47,15 +47,15 @@ export function parseAllDocsFromLlmsTxt(content: string): DocUrl[] {
       continue;
     }
 
-    // Parse doc links: - [Title](https://v3.heroui.com/docs/native/...): Description
+    // Parse doc links: - [Title](https://heroui.com/docs/native/...): Description
     const match = trimmed.match(/^- \[([^\]]+)\]\(([^)]+)\)(?:\s*:\s*(.+))?$/);
     if (match) {
       const [, title, url, description] = match;
 
       // Extract path from absolute URL
       let path = url;
-      if (url.startsWith("https://v3.heroui.com")) {
-        path = url.replace("https://v3.heroui.com", "");
+      if (url.startsWith("https://heroui.com")) {
+        path = url.replace("https://heroui.com", "");
       }
 
       // Include all Native docs

--- a/apps/native-mcp/src/extraction/utils/llms-parser.ts
+++ b/apps/native-mcp/src/extraction/utils/llms-parser.ts
@@ -47,15 +47,15 @@ export function parseAllDocsFromLlmsTxt(content: string): DocUrl[] {
       continue;
     }
 
-    // Parse doc links: - [Title](https://heroui.com/docs/native/...): Description
+    // Parse doc links: - [Title](https://www.heroui.com/docs/native/...): Description
     const match = trimmed.match(/^- \[([^\]]+)\]\(([^)]+)\)(?:\s*:\s*(.+))?$/);
     if (match) {
       const [, title, url, description] = match;
 
       // Extract path from absolute URL
       let path = url;
-      if (url.startsWith("https://heroui.com")) {
-        path = url.replace("https://heroui.com", "");
+      if (url.startsWith("https://www.heroui.com")) {
+        path = url.replace("https://www.heroui.com", "");
       }
 
       // Include all Native docs

--- a/apps/native-mcp/src/mcp/tools/get-component-docs.ts
+++ b/apps/native-mcp/src/mcp/tools/get-component-docs.ts
@@ -7,7 +7,7 @@ import {fetchApi} from "../lib/fetch";
 
 export const getComponentDocsTool: Tool<ComponentContext> = {
   name: "get_component_docs",
-  description: `Get complete HeroUI Native component documentation (including examples, props, usage) directly from v3.heroui.com.
+  description: `Get complete HeroUI Native component documentation (including examples, props, usage) directly from heroui.com.
 Accepts an array of component names and returns the full MDX documentation for each component.
 Returns raw markdown content from the component's .mdx file, which includes:
 - Import statements

--- a/apps/native-mcp/src/mcp/tools/get-docs.ts
+++ b/apps/native-mcp/src/mcp/tools/get-docs.ts
@@ -15,7 +15,7 @@ interface DocContentResponse {
 export const getDocsTool: Tool<DocsContext> = {
   name: "get_docs",
   description: `Get HeroUI Native documentation content for guides, principles, and release notes (NOT component docs).
-Fetches official documentation from v3.heroui.com.
+Fetches official documentation from heroui.com.
 Returns the complete MDX content of documentation pages.
 Use for understanding concepts, design principles, implementation guides, and version history.
 Documentation covers: getting started, theming, colors, styling, animation, release notes.

--- a/apps/react-mcp/README.md
+++ b/apps/react-mcp/README.md
@@ -150,7 +150,7 @@ List all available HeroUI v3 components (always returns latest version).
 
 ### `get_component_docs`
 
-Get complete component documentation (including examples, props, usage) directly from v3.heroui.com. This tool consolidates component information, props, and examples into a single call.
+Get complete component documentation (including examples, props, usage) directly from heroui.com. This tool consolidates component information, props, and examples into a single call.
 
 ```javascript
 // Parameters
@@ -207,7 +207,7 @@ Get the CSS styles (.css) for HeroUI components. Returns the complete CSS implem
 
 ### `get_docs`
 
-Get HeroUI v3 React documentation content for guides, principles, and release notes (NOT component docs). Fetches official documentation from v3.heroui.com.
+Get HeroUI v3 React documentation content for guides, principles, and release notes (NOT component docs). Fetches official documentation from heroui.com.
 
 ```javascript
 // Parameters

--- a/apps/react-mcp/src/api/legacy/routes/ctx.test.ts
+++ b/apps/react-mcp/src/api/legacy/routes/ctx.test.ts
@@ -132,7 +132,7 @@ describe("Legacy Context API", () => {
       if (res.status === 200 && data.docs.paths.length > 0) {
         // Verify that paths are normalized to path format (not full URLs)
         // The legacy ctx route transforms full URLs from llms.txt to paths
-        // e.g., https://v3.heroui.com/docs/react/components -> /docs/react/components
+        // e.g., https://heroui.com/docs/react/components -> /docs/react/components
         data.docs.paths.forEach((path: string) => {
           expect(path).toMatch(/^\/docs\//);
         });

--- a/apps/react-mcp/src/api/legacy/routes/ctx.ts
+++ b/apps/react-mcp/src/api/legacy/routes/ctx.ts
@@ -37,7 +37,7 @@ ctx.get("/", async (c) => {
     const [components, themes, docsResponse, version] = await Promise.allSettled([
       componentService.listComponents(LIBRARY_NAME),
       themeService.getAvailableThemes(),
-      fetch("https://v3.heroui.com/llms.txt").then((res) => res.text()),
+      fetch("https://heroui.com/llms.txt").then((res) => res.text()),
       componentService.getLatestVersion(LIBRARY_NAME),
     ]);
 
@@ -81,8 +81,8 @@ ctx.get("/", async (c) => {
             const [, title, url, description = ""] = match;
 
             let path = url;
-            if (url.startsWith("https://v3.heroui.com")) {
-              path = url.replace("https://v3.heroui.com", "");
+            if (url.startsWith("https://heroui.com")) {
+              path = url.replace("https://heroui.com", "");
             }
             currentCategory.docs.push({
               title,

--- a/apps/react-mcp/src/api/legacy/routes/docs.test.ts
+++ b/apps/react-mcp/src/api/legacy/routes/docs.test.ts
@@ -18,7 +18,7 @@ describe("Legacy Docs API", () => {
       expect(data).toHaveProperty("baseUrl");
       expect(data).toHaveProperty("categories");
       expect(data).toHaveProperty("total");
-      expect(data.baseUrl).toBe("https://v3.heroui.com");
+      expect(data.baseUrl).toBe("https://heroui.com");
       expect(Array.isArray(data.categories)).toBe(true);
       expect(typeof data.total).toBe("number");
     });

--- a/apps/react-mcp/src/api/legacy/routes/docs.ts
+++ b/apps/react-mcp/src/api/legacy/routes/docs.ts
@@ -18,7 +18,7 @@ interface DocCategory {
   docs: DocSection[];
 }
 
-// Get available documentation paths from v3.heroui.com
+// Get available documentation paths from heroui.com
 docs.get("/available", async (c) => {
   const endpoint = "list-docs";
   const startTime = Date.now();
@@ -26,7 +26,7 @@ docs.get("/available", async (c) => {
 
   try {
     // Fetch the llms.txt file from HeroUI v3 docs
-    const response = await fetch("https://v3.heroui.com/llms.txt");
+    const response = await fetch("https://heroui.com/llms.txt");
 
     if (!response.ok) {
       analytics.trackError({
@@ -37,7 +37,7 @@ docs.get("/available", async (c) => {
           apiVersion: "legacy",
           status: response.status,
           statusText: response.statusText,
-          url: "https://v3.heroui.com/llms.txt",
+          url: "https://heroui.com/llms.txt",
           responseTime: Date.now() - startTime,
         },
       });
@@ -103,7 +103,7 @@ docs.get("/available", async (c) => {
     });
 
     return c.json({
-      baseUrl: "https://v3.heroui.com",
+      baseUrl: "https://heroui.com",
       categories,
       total,
     });
@@ -183,7 +183,7 @@ docs.get("/content", async (c) => {
       // Add .mdx extension if not present
       const pathWithExt =
         cleanPath.endsWith(".mdx") || cleanPath.endsWith(".md") ? cleanPath : `${cleanPath}.mdx`;
-      docUrl = `https://v3.heroui.com${pathWithExt}`;
+      docUrl = `https://heroui.com${pathWithExt}`;
     }
 
     const response = await fetch(docUrl);
@@ -219,7 +219,7 @@ docs.get("/content", async (c) => {
       }
 
       analytics.trackError({
-        error: "Failed to fetch documentation from v3.heroui.com",
+        error: "Failed to fetch documentation from heroui.com",
         errorEvent: AnalyticsErrorEvent.GET_DOCS_CONTENT_ERROR,
         properties: {
           endpoint,

--- a/apps/react-mcp/src/api/routes/components.ts
+++ b/apps/react-mcp/src/api/routes/components.ts
@@ -90,7 +90,7 @@ components.post("/docs", zValidator("json", ComponentsRequestSchema), async (c) 
     const docResults = await Promise.all(
       componentNames.map(async (component) => {
         const kebabName = componentNameToKebab(component);
-        const docUrl = `https://v3.heroui.com/docs/react/components/${kebabName}.mdx`;
+        const docUrl = `https://heroui.com/docs/react/components/${kebabName}.mdx`;
 
         try {
           const response = await fetch(docUrl);

--- a/apps/react-mcp/src/api/routes/docs.ts
+++ b/apps/react-mcp/src/api/routes/docs.ts
@@ -53,7 +53,7 @@ docs.get("*", async (c) => {
 
     path = `/docs/${transformedPath}.mdx`;
 
-    const docUrl = `https://v3.heroui.com${path}`;
+    const docUrl = `https://heroui.com${path}`;
 
     const response = await fetch(docUrl);
 
@@ -120,7 +120,7 @@ docs.get("*", async (c) => {
       contentType,
     });
   } catch (error) {
-    const docUrl = `https://v3.heroui.com${path}`;
+    const docUrl = `https://heroui.com${path}`;
 
     analytics.trackError({
       error,

--- a/apps/react-mcp/src/extraction/extractors/components.ts
+++ b/apps/react-mcp/src/extraction/extractors/components.ts
@@ -66,7 +66,7 @@ export class ComponentExtractor extends BaseExtractor {
     console.log("🔍 Extracting HeroUI React components from llms.txt...");
 
     // Step 1: Fetch llms.txt
-    const llmsResponse = await fetch("https://v3.heroui.com/react/llms.txt");
+    const llmsResponse = await fetch("https://heroui.com/react/llms.txt");
     if (!llmsResponse.ok) {
       throw new Error(`Failed to fetch llms.txt: ${llmsResponse.status}`);
     }

--- a/apps/react-mcp/src/extraction/utils/llms-parser.ts
+++ b/apps/react-mcp/src/extraction/utils/llms-parser.ts
@@ -46,14 +46,14 @@ export function parseAllDocsFromLlmsTxt(content: string): DocUrl[] {
       continue;
     }
 
-    // Parse doc links: - [Title](https://heroui.com/docs/react/...): Description
+    // Parse doc links: - [Title](https://www.heroui.com/docs/react/...): Description
     const match = trimmed.match(/^- \[([^\]]+)\]\(([^)]+)\)(?:\s*:\s*(.+))?$/);
     if (match) {
       const [, title, url, description] = match;
 
       let path = url;
-      if (url.startsWith("https://heroui.com")) {
-        path = url.replace("https://heroui.com", "");
+      if (url.startsWith("https://www.heroui.com")) {
+        path = url.replace("https://www.heroui.com", "");
       }
 
       // Include all React docs

--- a/apps/react-mcp/src/extraction/utils/llms-parser.ts
+++ b/apps/react-mcp/src/extraction/utils/llms-parser.ts
@@ -46,14 +46,14 @@ export function parseAllDocsFromLlmsTxt(content: string): DocUrl[] {
       continue;
     }
 
-    // Parse doc links: - [Title](https://v3.heroui.com/docs/react/...): Description
+    // Parse doc links: - [Title](https://heroui.com/docs/react/...): Description
     const match = trimmed.match(/^- \[([^\]]+)\]\(([^)]+)\)(?:\s*:\s*(.+))?$/);
     if (match) {
       const [, title, url, description] = match;
 
       let path = url;
-      if (url.startsWith("https://v3.heroui.com")) {
-        path = url.replace("https://v3.heroui.com", "");
+      if (url.startsWith("https://heroui.com")) {
+        path = url.replace("https://heroui.com", "");
       }
 
       // Include all React docs

--- a/apps/react-mcp/src/mcp/tools/get-component-docs.ts
+++ b/apps/react-mcp/src/mcp/tools/get-component-docs.ts
@@ -7,7 +7,7 @@ import {fetchApi} from "../lib/fetch";
 
 export const getComponentDocsTool: Tool<ComponentContext> = {
   name: "get_component_docs",
-  description: `Get complete component documentation (including examples, props, usage) directly from v3.heroui.com.
+  description: `Get complete component documentation (including examples, props, usage) directly from heroui.com.
 Accepts an array of component names and returns the full MDX documentation for each component.
 Returns raw markdown content from the component's .mdx file, which includes:
 - Import statements

--- a/apps/react-mcp/src/mcp/tools/get-docs.ts
+++ b/apps/react-mcp/src/mcp/tools/get-docs.ts
@@ -15,7 +15,7 @@ interface DocContentResponse {
 export const getDocsTool: Tool<DocsContext> = {
   name: "get_docs",
   description: `Get HeroUI v3 React documentation content for guides, principles, and release notes (NOT component docs).
-Fetches official documentation from v3.heroui.com.
+Fetches official documentation from heroui.com.
 Returns the complete MDX content of documentation pages.
 Use for understanding concepts, design principles, implementation guides, and version history.
 Documentation covers: getting started, theming, colors, styling, animation, release notes.


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR is to update heroui link from `v3.heroui.com` to `heroui.com`. Even thought there is a redirection, some logic like llms.txt parser would extract components based on the prefix. Below example shows [llms.txt](https://heroui.com/react/llms.txt) is using `https://www.heroui.com`, not `https://v3.heroui.com`, which results in 0 components found in the extractor.
```
- [All Components](https://www.heroui.com/docs/react/components): Explore the full list of components available in the library. More are on the way.
```

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/heroui-inc/heroui-mcp/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
